### PR TITLE
Auto-referencing of template script now works on OSX as well

### DIFF
--- a/hibiscus-ui/gulp/magnolia-lighter/gulp-lighter-auto-ref.js
+++ b/hibiscus-ui/gulp/magnolia-lighter/gulp-lighter-auto-ref.js
@@ -53,7 +53,7 @@ module.exports = function() {
 
             //Check for existance of file
             // @@ hibiscus ADJUSTMENT
-            var pathScript = (file.base + relPathScript).replace('source\\yaml\\','magnolia-resources\\');
+            var pathScript = (file.base + relPathScript).replace('source/yaml/','magnolia-resources/').replace('source\\yaml\\','magnolia-resources\\');
             // console.log("pathScript:" + pathScript);
             try {
                 var stats = fs.statSync(pathScript);


### PR DESCRIPTION
I changed line 56 to use the same trick as you use in line 73 to get it to work on OSX as well as windows.
With this change, everything works on my mac. (Really cool by the way.)
I have not tested this on windows.
